### PR TITLE
Better explanation about the use_simple_annotation_reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ Configuration
        files are located. Example: `Path\To\Foo\Resources\mappings`
 
      Each **annotation** mapping may also specify the following options:
-     * **use_simple_annotation_reader**: If `true`, the notation `@Entity`
-       will work, otherwise, the notation `@ORM\Entity` will be supported.
+     * **use_simple_annotation_reader**: If `true`, only the notation `@Entity`
+       will work, otherwise, the notation `@ORM\Entity` and similar (`@Doctrine\ORM\Mapping\Entity`, ... and so on) will also be supported.
    * **query_cache**:
      String or array describing query cache implementation.
      *Default: setting specified by orm.default_cache*


### PR DESCRIPTION
Differences for the usage of the simple annotation reader. If it is not activated, then _everything_ will work, as long as it can be autoloaded.

I think maybe you should specify that when you do not use the simple annotation reader, then you should register your autoloader (composer, ... whatever) with the following (if it's composer, as it need to be adapted) :

``` php
<?php
// ...

$loader = require __DIR__ . '/../vendor/autoload.php';

\Doctrine\Common\Annotations\AnnotationRegistry::registerLoader(array($loader, 'loadClass'));
```

I think maybe trying to create an "autoloader" service provider for Silex (as this was removed), and checking if there is such a service provider could be maybe be useful to register it automatically ? Like the following :

``` php
<?php
// ...

if (isset($app['autoloader'])) {
   \Doctrine\Common\Annotations\AnnotationRegistry::registerLoader($app['autoloader']);
}
```

But it's up to you. :)
