### PR TITLE
Fix typos in entity manager configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ $container["orm.em.options"] = array(
         // (requires registering a PSR-0 Resource Locator
         // Service Provider)
         array(
-            "type" => "annotations",
+            "type" => "annotation",
             "namespace" => "Baz\Entities",
             "resources_namespace" => "Baz\Entities",
         ),


### PR DESCRIPTION
Otherwise exception "annotations is not a recognized driver" is thrown.
