### PR TITLE
Make DoctrineOrmServiceProvider managers lazy

### DIFF
--- a/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
+++ b/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
@@ -91,7 +91,7 @@ class DoctrineOrmServiceProvider
                     $config = $app['orm.ems.config'][$name];
                 }
 
-                $ems[$name] = $app->share(function () use ($app, $options, $config) {
+                $ems[$name] = $app->share(function ($ems) use ($app, $options, $config) {
                     return EntityManager::create(
                         $app['dbs'][$options['connection']],
                         $config,


### PR DESCRIPTION
Specifically, do not create all managers early, only create them as
needed.
