### PR TITLE
Topics/improve memcache

### DIFF
--- a/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
+++ b/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
@@ -200,12 +200,17 @@ class DoctrineOrmServiceProvider
         });
 
         $app['orm.cache.factory.memcache'] = $app->protect(function($cacheOptions) use ($app) {
-            if (empty($cacheOptions['host']) || empty($cacheOptions['port'])) {
-                throw new \RuntimeException('Host and port options need to be specified for memcache cache');
+            if (empty($cacheOptions['host'])) {
+                throw new \RuntimeException('Host needs to be specified for memcache cache');
+            }
+
+            $port = 11211;
+            if ($cacheOptions['port']) {
+                $port = $cacheOptions['port'];
             }
 
             $memcache = $app['orm.cache.factory.backing_memcache']();
-            $memcache->connect($cacheOptions['host'], $cacheOptions['port']);
+            $memcache->connect($cacheOptions['host'], $port);
 
             $cache = new MemcacheCache;
             $cache->setMemcache($memcache);

--- a/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
+++ b/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
@@ -212,7 +212,7 @@ class DoctrineOrmServiceProvider
             }
 
             $memcache = $app['orm.cache.factory.backing_memcache'];
-            $memcache->connect($cacheOptions['host'], $port);
+            $memcache->addServer($cacheOptions['host'], $port);
 
             $cache = new MemcacheCache;
             $cache->setMemcache($memcache);

--- a/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
+++ b/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
@@ -211,7 +211,11 @@ class DoctrineOrmServiceProvider
                 $port = $cacheOptions['port'];
             }
 
-            $memcache = $app['orm.cache.factory.backing_memcache'];
+            if ($app['orm.cache.factory.backing_memcache'] instanceof \Memcache) {
+                $memcache = $app['orm.cache.factory.backing_memcache'];
+            } else {
+                $memcache = $app['orm.cache.factory.backing_memcache']();
+            }
             $memcache->addServer($cacheOptions['host'], $port);
 
             $cache = new MemcacheCache;

--- a/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
+++ b/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
@@ -195,9 +195,11 @@ class DoctrineOrmServiceProvider
             return $app[$cacheInstanceKey] = $app['orm.cache.factory']($driver, $options);
         });
 
-        $app['orm.cache.factory.backing_memcache'] = $app->protect(function() {
-            return new \Memcache;
-        });
+        if (false === isset($app['orm.cache.factory.backing_memcache'])) {
+            $app['orm.cache.factory.backing_memcache'] = $app->protect(function() {
+                return new \Memcache;
+            });
+        }
 
         $app['orm.cache.factory.memcache'] = $app->protect(function($cacheOptions) use ($app) {
             if (empty($cacheOptions['host'])) {
@@ -209,7 +211,7 @@ class DoctrineOrmServiceProvider
                 $port = $cacheOptions['port'];
             }
 
-            $memcache = $app['orm.cache.factory.backing_memcache']();
+            $memcache = $app['orm.cache.factory.backing_memcache'];
             $memcache->connect($cacheOptions['host'], $port);
 
             $cache = new MemcacheCache;


### PR DESCRIPTION
Hey,

I hacked in some changes for the service provider.

We were primarily after injecting an already configured Memcache object.

And I made the `port` optional.

Before you use the service provider, you can setup Memcache with multiple servers like so:

``` php
$memcache = new \Memcache;
$memcache->addServer('node1', 11211);
$memcache->addServer('node2', 11211);
$memcache->addServer('node3', 11211);

$app['orm.cache.factory.backing_memcache'] = $memcache;
```

Let me know if you guys have any suggestions.
