### PR TITLE
Use options defined for the specific cache

### DIFF
--- a/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
+++ b/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
@@ -192,7 +192,7 @@ class DoctrineOrmServiceProvider
                 return $app[$cacheInstanceKey];
             }
 
-            return $app[$cacheInstanceKey] = $app['orm.cache.factory']($driver, $options);
+            return $app[$cacheInstanceKey] = $app['orm.cache.factory']($driver, $options[$cacheNameKey]);
         });
 
         $app['orm.cache.factory.backing_memcache'] = $app->protect(function() {


### PR DESCRIPTION
When creating a cache driver, we must specify some options, but these are not passed to the driver constructor as it should.

The use case for this is to do something like this:

``` php
$app['orm.default_cache'] = array('driver' => 'memcached', 'host' => 'localhost', 'port' => 11211);
```
