### PR TITLE
Adding "cache_namespace" key in "orm.em.options"

### DIFF
--- a/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
+++ b/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
@@ -110,9 +110,6 @@ class DoctrineOrmServiceProvider
             foreach ($app['orm.ems.options'] as $name => $options) {
                 $config = new Configuration;
 
-
-
-
                 $app['orm.cache.configurer']($name, $config, $options);
 
                 $config->setProxyDir($app['orm.proxies_dir']);
@@ -249,7 +246,7 @@ class DoctrineOrmServiceProvider
         });
 
         $app['orm.cache.factory.apc'] = $app->protect(function() {
-            return new ApcCache();
+            return new ApcCache;
         });
 
         $app['orm.cache.factory.xcache'] = $app->protect(function() {
@@ -258,12 +255,11 @@ class DoctrineOrmServiceProvider
 
         $app['orm.cache.factory'] = $app->protect(function($driver, $cacheOptions) use ($app) {
 
-
             switch ($driver) {
                 case 'array':
                     return $app['orm.cache.factory.array']();
                 case 'apc':
-                    return $app['orm.cache.factory.apc']($cacheOptions);
+                    return $app['orm.cache.factory.apc']();
                 case 'xcache':
                     return $app['orm.cache.factory.xcache']();
                 case 'memcache':


### PR DESCRIPTION
In reference to issue #15 

When you have many web applications in the same server, it is necessary to configure a suffix in the APC cache in order to avoid cache conficts between applications.

With this patch, you can configure it in this way:

```
    $app->register(new Dflydev\Silex\Provider\DoctrineOrm\DoctrineOrmServiceProvider, array(
        "orm.em.options" => array(
            "cache_namespace" => "appname_",
            "metadata_cache" => "apc",
            "query_cache"    => "apc",
            "mappings" => array(
                array(),
            ),
        ),
    ));
```
