### PR TITLE
Allow for setting a cache namespace

### DIFF
--- a/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
+++ b/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
@@ -13,6 +13,7 @@ namespace Dflydev\Pimple\Provider\DoctrineOrm;
 
 use Doctrine\Common\Cache\ApcCache;
 use Doctrine\Common\Cache\ArrayCache;
+use Doctrine\Common\Cache\CacheProvider;
 use Doctrine\Common\Cache\MemcacheCache;
 use Doctrine\Common\Cache\MemcachedCache;
 use Doctrine\Common\Cache\XcacheCache;
@@ -192,7 +193,13 @@ class DoctrineOrmServiceProvider
                 return $app[$cacheInstanceKey];
             }
 
-            return $app[$cacheInstanceKey] = $app['orm.cache.factory']($driver, $options[$cacheNameKey]);
+            $cache = $app['orm.cache.factory']($driver, $options[$cacheNameKey]);
+
+            if(isset($options['cache_namespace']) && $cache instanceof CacheProvider) {
+                $cache->setNamespace($options['cache_namespace']);
+            }
+
+            return $app[$cacheInstanceKey] = $cache;
         });
 
         $app['orm.cache.factory.backing_memcache'] = $app->protect(function() {


### PR DESCRIPTION
If `cache_namespace` is set, `setNamespace` will be called on the resulting cache instance if it is a Doctrine CacheProvider instance. Doctrine's CacheProvider will take care of normalizing this call for various backends based on its own rules.

```
$app->register(
    new Dflydev\Silex\Provider\DoctrineOrm\DoctrineOrmServiceProvider,
    array(
        'orm.em.options' => array(
            'cache_namespace' => 'appname_',
            'metadata_cache' => 'apc',
            'query_cache'    => 'apc',
            'mappings' => array(
                array(),
            ),
        ),
    )
);
```

Thanks to @asiermarques for this work.

Closes #15
Closes #16
