### PR TITLE
remove unneeded passing of Pimple $app

### DIFF
--- a/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
+++ b/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
@@ -38,7 +38,7 @@ class DoctrineOrmServiceProvider
 {
     public function register(\Pimple $app)
     {
-        foreach ($this->getOrmDefaults($app) as $key => $value) {
+        foreach ($this->getOrmDefaults() as $key => $value) {
             if (!isset($app[$key])) {
                 $app[$key] = $value;
             }
@@ -375,7 +375,7 @@ class DoctrineOrmServiceProvider
      *
      * @return array
      */
-    protected function getOrmDefaults(\Pimple $app)
+    protected function getOrmDefaults()
     {
         return array(
             'orm.proxies_dir' => __DIR__.'/../../../../../../../../cache/doctrine/proxies',


### PR DESCRIPTION
The $app variable is passed needlessly to getOrmDefaults
