### PR TITLE
Use Pimple\Container instead of Pimple for $configs

### DIFF
--- a/src/Dflydev/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
+++ b/src/Dflydev/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
@@ -117,7 +117,7 @@ class DoctrineOrmServiceProvider implements ServiceProviderInterface
         $container['orm.ems.config'] = function ($container) {
             $container['orm.ems.options.initializer']();
 
-            $configs = new \Pimple();
+            $configs = new Container();
             foreach ($container['orm.ems.options'] as $name => $options) {
                 $config = new Configuration;
 


### PR DESCRIPTION
By using \Pimple instead of Container (already using Pimple\Container) it's throwing an exception:
Case mismatch between loaded and declared class names: Pimple vs Pimple\Container
