### PR TITLE
Updating to require pimple ~3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "pimple/pimple": "~3.0",
+        "pimple/pimple": ">=2.1,<4",
         "doctrine/orm": "~2.3"
     },
     "autoload": {


### PR DESCRIPTION
Silex 2.0.x has been updated to require pimple ~3.0 which makes this library incompatible with silex 2.0.x.  There is no difference between pimple 2.1.1 and 3.0.0 just a version bump.
