### PR TITLE
Add auth cache option for Redis

### DIFF
--- a/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
+++ b/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
@@ -295,6 +295,10 @@ class DoctrineOrmServiceProvider
             $redis = $app['orm.cache.factory.backing_redis']();
             $redis->connect($cacheOptions['host'], $cacheOptions['port']);
 
+            if (isset($cacheOptions['password'])) {
+                $redis->auth($cacheOptions['password']);
+            }
+
             $cache = new RedisCache;
             $cache->setRedis($redis);
 


### PR DESCRIPTION
In order to authenticate with the Redis server prior to sending commands, `Redis::auth()` must be invoked. This change enhances the `'orm.cache.factory.redis'` factory to recognise the `'password'` option, which, if provided, is passed into `Redis::auth()`.