### PR TITLE
Use an array of configuration for "orm.default_cache" value

### DIFF
--- a/src/Dflydev/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
+++ b/src/Dflydev/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
@@ -448,7 +448,9 @@ class DoctrineOrmServiceProvider implements ServiceProviderInterface
             'orm.proxies_dir' => __DIR__.'/../../../../../../../../cache/doctrine/proxies',
             'orm.proxies_namespace' => 'DoctrineProxy',
             'orm.auto_generate_proxies' => true,
-            'orm.default_cache' => 'array',
+            'orm.default_cache' => array(
+                'driver' => 'array',
+            ),
             'orm.custom.functions.string' => array(),
             'orm.custom.functions.numeric' => array(),
             'orm.custom.functions.datetime' => array(),


### PR DESCRIPTION
Having the default value as a string makes it trickier to merge other default values.

E.g. if using something like https://github.com/igorw/ConfigServiceProvider you maybe want to override the `orm.default_cache` option on production to use memcache by default. You need an array for this like:

```
[
  'driver' =>  'memcached',
  'host' => '127.0.0.1'
  'port' => '11211',
  'cache_namespace' => 'some_namespace',
]
```

You can't merge that by default as it's currently just a string value.

If we used an array of configuration instead, we could always merge:

```
[
  'driver' => 'array',
]
```