### PR TITLE
[feature] Use the annotation cache metadata

### DIFF
--- a/src/Dflydev/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
+++ b/src/Dflydev/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
@@ -163,8 +163,13 @@ class DoctrineOrmServiceProvider implements ServiceProviderInterface
                                 isset($entity['use_simple_annotation_reader'])
                                 ? $entity['use_simple_annotation_reader']
                                 : true;
-                            $driver = $config->newDefaultAnnotationDriver((array) $entity['path'], $useSimpleAnnotationReader);
-                            $chain->addDriver($driver, $entity['namespace']);
+                                 if (!isset($app["orm.ems.annotation.driver"])) {
+                                    $driver = $config->newDefaultAnnotationDriver((array) $entity['path'], $useSimpleAnnotationReader);
+                                    $chain->addDriver($driver, $entity['namespace']);
+                                break;
+                            }
+
+                            $chain->addDriver($app["orm.ems.annotation.driver"], $entity['namespace']);
                             break;
                         case 'yml':
                             $driver = new YamlDriver($entity['path']);


### PR DESCRIPTION
in production is usefule let the user to the user configure a service 

``` php

$cache = new ApcCache(); //or whatever

AnnotationRegistry::registerFile(__DIR__ . '/Mapping/Driver/DoctrineAnnotations.php');

        if ($useSimpleAnnotationReader) {
            // Register the ORM Annotations in the AnnotationRegistry
            $reader = new SimpleAnnotationReader();
            $reader->addNamespace('Doctrine\ORM\Mapping');
            $cachedReader = new CachedReader($reader, $cache);

            return new AnnotationDriver($cachedReader, (array) $paths);
        }

        return new AnnotationDriver(
            new CachedReader(new AnnotationReader(), $cache),
            (array) $paths
        );
```