### PR TITLE
Fix: Install dependencies in install section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ cache:
   directories:
     - $HOME/.composer/cache
 
-before_script:
+install:
   - composer install --prefer-dist
 
 script: phpunit --coverage-text --verbose


### PR DESCRIPTION
This PR
- [x] moves installation of dependencies on Travis to `install` section
