### PR TITLE
Support filesystem cache options

### DIFF
--- a/src/Dflydev/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
+++ b/src/Dflydev/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
@@ -325,7 +325,11 @@ class DoctrineOrmServiceProvider implements ServiceProviderInterface
                 throw new \RuntimeException('FilesystemCache path not defined');
             }
 
-            return new FilesystemCache($cacheOptions['path']);
+            $cacheOptions += array(
+                'extension' => FilesystemCache::EXTENSION,
+                'umask' => 0002,
+            );
+            return new FilesystemCache($cacheOptions['path'], $cacheOptions['extension'], $cacheOptions['umask']);
         });
 
         $container['orm.cache.factory.couchbase'] = $container->protect(function($cacheOptions){


### PR DESCRIPTION
Doctrine Cache recently introduced [a new umask constructor argument](https://github.com/doctrine/cache/commit/5d9340412c24706f9ac5cd34a58e91592f2ce130).

This PR adds the possibility to inject the umask together with the other cache config options.

I would appreciate if this could also be merged into the 1.x branch :-) Let me know if I need to do anything particular in that regard (e.g. create a separate PR).