### PR TITLE
Support custom cache drivers in orm.cache.factory

### DIFF
--- a/src/Dflydev/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
+++ b/src/Dflydev/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
@@ -357,26 +357,12 @@ class DoctrineOrmServiceProvider implements ServiceProviderInterface
         });
 
         $container['orm.cache.factory'] = $container->protect(function ($driver, $cacheOptions) use ($container) {
-            switch ($driver) {
-                case 'array':
-                    return $container['orm.cache.factory.array']();
-                case 'apc':
-                    return $container['orm.cache.factory.apc']();
-                case 'xcache':
-                    return $container['orm.cache.factory.xcache']();
-                case 'memcache':
-                    return $container['orm.cache.factory.memcache']($cacheOptions);
-                case 'memcached':
-                    return $container['orm.cache.factory.memcached']($cacheOptions);
-                case 'filesystem':
-                    return $container['orm.cache.factory.filesystem']($cacheOptions);
-                case 'redis':
-                    return $container['orm.cache.factory.redis']($cacheOptions);
-                case 'couchbase':
-                    return $container['orm.cache.factory.couchbase']($cacheOptions);
-                default:
-                    throw new \RuntimeException("Unsupported cache type '$driver' specified");
+            $cacheFactoryKey = 'orm.cache.factory.'.$driver;
+            if (!isset($container[$cacheFactoryKey])) {
+                throw new \RuntimeException("Factory '$cacheFactoryKey' for cache type '$driver' not defined (is it spelled correctly?)");
             }
+
+            return $container[$cacheFactoryKey]($cacheOptions);
         });
 
         $container['orm.mapping_driver_chain.locator'] = $container->protect(function ($name = null) use ($container) {

--- a/tests/Dflydev/Tests/Provider/DoctrineOrm/DoctrineOrmServiceProviderTest.php
+++ b/tests/Dflydev/Tests/Provider/DoctrineOrm/DoctrineOrmServiceProviderTest.php
@@ -226,7 +226,7 @@ class DoctrineOrmServiceProviderTest extends \PHPUnit_Framework_TestCase
 
             $this->fail('Expected invalid query cache driver exception');
         } catch (\RuntimeException $e) {
-            $this->assertEquals("Unsupported cache type 'INVALID' specified", $e->getMessage());
+            $this->assertEquals("Factory 'orm.cache.factory.INVALID' for cache type 'INVALID' not defined (is it spelled correctly?)", $e->getMessage());
         }
     }
 
@@ -250,7 +250,7 @@ class DoctrineOrmServiceProviderTest extends \PHPUnit_Framework_TestCase
 
             $this->fail('Expected invalid query cache driver exception');
         } catch (\RuntimeException $e) {
-            $this->assertEquals("Unsupported cache type 'INVALID' specified", $e->getMessage());
+            $this->assertEquals("Factory 'orm.cache.factory.INVALID' for cache type 'INVALID' not defined (is it spelled correctly?)", $e->getMessage());
         }
     }
 


### PR DESCRIPTION
The cache driver factory, orm.cache.factory, only supports the predefined cache drivers.

With this PR, the factory also supports custom cache drivers.
