### PR TITLE
Allow user to inject their own cache object

### DIFF
--- a/src/Dflydev/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
+++ b/src/Dflydev/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
@@ -357,6 +357,10 @@ class DoctrineOrmServiceProvider implements ServiceProviderInterface
         });
 
         $container['orm.cache.factory'] = $container->protect(function ($driver, $cacheOptions) use ($container) {
+            if ($driver instanceof CacheProvider) {
+                return $driver;
+            }
+
             $cacheFactoryKey = 'orm.cache.factory.'.$driver;
             if (!isset($container[$cacheFactoryKey])) {
                 throw new \RuntimeException("Factory '$cacheFactoryKey' for cache type '$driver' not defined (is it spelled correctly?)");

--- a/tests/Dflydev/Tests/Provider/DoctrineOrm/DoctrineOrmServiceProviderTest.php
+++ b/tests/Dflydev/Tests/Provider/DoctrineOrm/DoctrineOrmServiceProviderTest.php
@@ -12,6 +12,8 @@
 namespace Dflydev\Tests\Provider\DoctrineOrm;
 
 use Dflydev\Provider\DoctrineOrm\DoctrineOrmServiceProvider;
+use Doctrine\Common\Cache\VoidCache;
+use Doctrine\ORM\EntityManager;
 use Pimple\Container;
 
 /**
@@ -252,6 +254,19 @@ class DoctrineOrmServiceProviderTest extends \PHPUnit_Framework_TestCase
         } catch (\RuntimeException $e) {
             $this->assertEquals("Factory 'orm.cache.factory.INVALID' for cache type 'INVALID' not defined (is it spelled correctly?)", $e->getMessage());
         }
+    }
+
+    /**
+     * User can inject their own cache object.
+     */
+    public function testCacheInjection() {
+        $container = $this->createMockDefaultApp();
+
+        $container->register(new DoctrineOrmServiceProvider, array('orm.default_cache' => new VoidCache()));
+
+        /** @var EntityManager $em */
+        $em = $container['orm.em'];
+        $this->assertInstanceOf('Doctrine\Common\Cache\VoidCache', $em->getConfiguration()->getHydrationCacheImpl());
     }
 
     /**


### PR DESCRIPTION
I was able to inject cache object to this service provider, but I can't now. Can you provide BC?

In my application, I want use single chain cache object for all service providers instead of create a lot of cache objects.

Thanks