### PR TITLE
Fix silex namespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ php:
   - 5.5
 
 before_script:
-  - composer install --dev
+  - composer install --prefer-source
 
 script: phpunit --coverage-text --verbose

--- a/README.md
+++ b/README.md
@@ -230,6 +230,8 @@ Configuration
      String or array describing metadata cache implementation.
    * **result_cache** (Default: setting specified by orm.default_cache):
      String or array describing result cache implementation.
+   * **types**
+     An array of custom types in the format of 'typeName' => 'Namespace\To\Type\Class'
  * **orm.ems.options**:
    Array of Entity Manager configuration sets indexed by each Entity Manager's
    name. Each value should look like **orm.em.options**.

--- a/README.md
+++ b/README.md
@@ -145,6 +145,15 @@ $app->register(new DoctrineOrmServiceProvider, array(
                 "namespace" => "Bat\Entities",
                 "path" => __DIR__."/src/Bat/Resources/mappings",
             ),
+            // As of 1.1, you can also use the simplified
+            // XML/YAML driver (Symfony2 style)
+            // Mapping files can be named like Foo.orm.yml
+            // instead of Baz.Entities.Foo.dcm.yml
+            array(
+                "type" => "simple_yml",
+                "namespace" => "Baz\Entities",
+                "path" => __DIR__."/src/Bat/Resources/config/doctrine",
+            ),
             // Using PSR-0 namespaceish embedded resources
             // (requires registering a PSR-0 Resource Locator
             // Service Provider)
@@ -201,8 +210,10 @@ Configuration
 
      Each mapping definition should be an array with the following
      options:
-     * **type**: Mapping driver type, one of `annotation`, `xml`, `yml` or `php`.
+     * **type**: Mapping driver type, one of `annotation`, `xml`, `yml`, `simple_xml`, `simple_yml` or `php`.
      * **namespace**: Namespace in which the entities reside.
+
+     *New: the `simple_xml` and `simple_yml` driver types were added in v1.1 and provide support for the [simplified XML driver][10] and [simplified YAML driver][11] of Doctrine.*
 
      Additionally, each mapping definition should contain one of the
      following options:
@@ -405,6 +416,8 @@ Some inspiration was also taken from [Doctrine Bundle][4] and
 [7]: https://packagist.org/packages/dflydev/doctrine-orm-service-provider
 [8]: https://github.com/Cilex/Cilex/blob/master/src/Cilex/Provider/DoctrineServiceProvider.php
 [9]: https://github.com/saxulum/saxulum-doctrine-orm-manager-registry-provider
+[10]: http://docs.doctrine-project.org/en/latest/reference/xml-mapping.html#simplified-xml-driver
+[11]: http://docs.doctrine-project.org/en/latest/reference/yaml-mapping.html#simplified-yaml-driver
 
 [#dflydev]: irc://irc.freenode.net/#dflydev
 [#silex-php]: irc://irc.freenode.net/#silex-php

--- a/README.md
+++ b/README.md
@@ -367,6 +367,11 @@ $loader = require __DIR__ . '/../vendor/autoload.php';
 \Doctrine\Common\Annotations\AnnotationRegistry::registerLoader(array($loader, 'loadClass'));
 ```
 
+### Why is there no manager registry implementation?
+
+There is allready a thirdparty `ManagerRegistry` implementation at [saxulum-doctrine-orm-manager-registry-provider][9].
+It support the `entity` type known of the form component, adds the `UniqueEntity` validator and a command line integration.
+
 License
 -------
 
@@ -399,6 +404,7 @@ Some inspiration was also taken from [Doctrine Bundle][4] and
 [6]: http://github.com/dflydev/dflydev-psr0-resource-locator-service-provider
 [7]: https://packagist.org/packages/dflydev/doctrine-orm-service-provider
 [8]: https://github.com/Cilex/Cilex/blob/master/src/Cilex/Provider/DoctrineServiceProvider.php
+[9]: https://github.com/saxulum/saxulum-doctrine-orm-manager-registry-provider
 
 [#dflydev]: irc://irc.freenode.net/#dflydev
 [#silex-php]: irc://irc.freenode.net/#silex-php

--- a/README.md
+++ b/README.md
@@ -230,6 +230,8 @@ Configuration
      String or array describing metadata cache implementation.
    * **result_cache** (Default: setting specified by orm.default_cache):
      String or array describing result cache implementation.
+   * **hydration_cache** (Default: setting specified by orm.default_cache):
+     String or array describing hydration cache implementation.
    * **types**
      An array of custom types in the format of 'typeName' => 'Namespace\To\Type\Class'
  * **orm.ems.options**:
@@ -268,6 +270,13 @@ Configuration
    String defining namespace in which Doctrine generated proxies should reside.
  * **orm.auto_generate_proxies**:
    Boolean defining whether or not proxies should be generated automatically.
+ * **orm.class_metadata_factory_name**: Class name of class metadata factory.
+   Class implements `Doctrine\Common\Persistence\Mapping\ClassMetadataFactory`.
+ * **orm.default_repository_class**: Class name of default repository.
+   Class implements `Doctrine\Common\Persistence\ObjectRepository`.
+ * **orm.repository_factory**: Repository factory, instance `Doctrine\ORM\Repository\RepositoryFactory`.
+ * **orm.entity_listener_resolver**: Entity listener resolver, instance
+   `Doctrine\ORM\Mapping\EntityListenerResolver`.
  * **orm.default_cache**:
    String or array describing default cache implementation.
  * **orm.add_mapping_driver**:
@@ -322,6 +331,15 @@ Configuration
        return $config;
    }));
    ```
+ * **orm.strategy**:
+   * **naming**: Naming strategy, instance `Doctrine\ORM\Mapping\NamingStrategy`.
+   * **quote**: Quote strategy, instance `Doctrine\ORM\Mapping\QuoteStrategy`.
+ * **orm.custom.functions**:
+   * **string**, **numeric**, **datetime**: Custom DQL functions, array of class names indexed by DQL function name.
+     Classes are subclasses of `Doctrine\ORM\Query\AST\Functions\FunctionNode`.
+   * **hydration_modes**: Hydrator class names, indexed by hydration mode name.
+     Classes are subclasses of `Doctrine\ORM\Internal\Hydration\AbstractHydrator`.
+  
 
 ### Services
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+## v1.0.4 (2013-12-11)
+
+ * @mrkrstphr: Custom types (#21)
+
 ## v1.0.3 (2013-10-25)
 
  * @tdbui83: Redis cache (#20)

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,6 @@
+## v1.1.0-dev
+ * @dirkluijk: Added support for simple YAML/XML drivers
+
 ## v1.0.5 (2014-06-17)
 
  * @c960657: Support remaining config options (#22)

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+## v1.0.5 (2014-06-17)
+
+ * @c960657: Support remaining config options (#22)
+ * @iolloyd: Remove unneeded passing of Pimple $app (#25)
+
 ## v1.0.4 (2013-12-11)
 
  * @mrkrstphr: Custom types (#21)

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+## v1.0.7 (2015-09-07)
+
+ * @c960657: Security fix for FileCache (#57)
+
 ## v1.0.6 (2014-07-24)
 
  * @dirkluijk: Added support for simple YAML/XML drivers

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
-## v1.0.x-dev
+## v1.0.3 (2013-10-25)
 
+ * @tdbui83: Redis cache (#20)
  * @Richard-NL: Filesystem cache (#19)
 
 ## v1.0.2 (2013-09-19)

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,5 @@
-## v1.1.0-dev
+## v1.0.6 (2014-07-24)
+
  * @dirkluijk: Added support for simple YAML/XML drivers
 
 ## v1.0.5 (2014-06-17)

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "dflydev/doctrine-orm-service-provider",
     "description": "Doctrine ORM Service Provider",
     "keywords": ["pimple", "cilex", "silex", "doctrine", "orm"],
+    "homepage": "http://dflydev.com/projects/doctrine-orm-service-provider/",
     "license": "MIT",
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -35,10 +35,5 @@
             "Dflydev\\Pimple\\Provider\\DoctrineOrm": "src",
             "Dflydev\\Silex\\Provider\\DoctrineOrm": "src"
         }
-    },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "1.0-dev"
-        }
     }
 }

--- a/src/Dflydev/Cilex/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
+++ b/src/Dflydev/Cilex/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
@@ -12,8 +12,8 @@
 namespace Dflydev\Cilex\Provider\DoctrineOrm;
 
 use Dflydev\Pimple\Provider\DoctrineOrm\DoctrineOrmServiceProvider as PimpleDoctrineOrmServiceProvider;
-use Cilex\Application;
-use Cilex\ServiceProviderInterface;
+use Silex\Application;
+use Silex\ServiceProviderInterface;
 
 /**
  * Doctrine ORM Cilex Service Provider.

--- a/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
+++ b/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
@@ -21,6 +21,7 @@ use Doctrine\Common\Cache\XcacheCache;
 use Doctrine\Common\Cache\RedisCache;
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriver;
 use Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain;
+use Doctrine\DBAL\Types\Type;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Mapping\Driver\Driver;
@@ -46,6 +47,7 @@ class DoctrineOrmServiceProvider
         $app['orm.em.default_options'] = array(
             'connection' => 'default',
             'mappings' => array(),
+            'types' => array()
         );
 
         $app['orm.ems.options.initializer'] = $app->protect(function () use ($app) {
@@ -162,6 +164,14 @@ class DoctrineOrmServiceProvider
                     }
                 }
                 $config->setMetadataDriverImpl($chain);
+
+                foreach ((array) $options['types'] as $typeName => $typeClass) {
+                    if (Type::hasType($typeName)) {
+                        Type::overrideType($typeName, $typeClass);
+                    } else {
+                        Type::addType($typeName, $typeClass);
+                    }
+                }
 
                 $configs[$name] = $config;
             }

--- a/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
+++ b/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
@@ -295,6 +295,10 @@ class DoctrineOrmServiceProvider
             $redis = $app['orm.cache.factory.backing_redis']();
             $redis->connect($cacheOptions['host'], $cacheOptions['port']);
 
+            if (isset($cacheOptions['password'])) {
+                $redis->auth($cacheOptions['password']);
+            }
+
             $cache = new RedisCache;
             $cache->setRedis($redis);
 

--- a/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
+++ b/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
@@ -42,7 +42,7 @@ class DoctrineOrmServiceProvider
 {
     public function register(\Pimple $app)
     {
-        foreach ($this->getOrmDefaults($app) as $key => $value) {
+        foreach ($this->getOrmDefaults() as $key => $value) {
             if (!isset($app[$key])) {
                 $app[$key] = $value;
             }
@@ -410,7 +410,7 @@ class DoctrineOrmServiceProvider
      *
      * @return array
      */
-    protected function getOrmDefaults(\Pimple $app)
+    protected function getOrmDefaults()
     {
         return array(
             'orm.proxies_dir' => __DIR__.'/../../../../../../../../cache/doctrine/proxies',

--- a/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
+++ b/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
@@ -28,6 +28,8 @@ use Doctrine\ORM\Mapping\DefaultEntityListenerResolver;
 use Doctrine\ORM\Mapping\DefaultNamingStrategy;
 use Doctrine\ORM\Mapping\DefaultQuoteStrategy;
 use Doctrine\ORM\Mapping\Driver\Driver;
+use Doctrine\ORM\Mapping\Driver\SimplifiedXmlDriver;
+use Doctrine\ORM\Mapping\Driver\SimplifiedYamlDriver;
 use Doctrine\ORM\Mapping\Driver\XmlDriver;
 use Doctrine\ORM\Mapping\Driver\YamlDriver;
 use Doctrine\ORM\Mapping\Driver\StaticPHPDriver;
@@ -168,8 +170,16 @@ class DoctrineOrmServiceProvider
                             $driver = new YamlDriver($entity['path']);
                             $chain->addDriver($driver, $entity['namespace']);
                             break;
+                        case 'simple_yml':
+                            $driver = new SimplifiedYamlDriver(array($entity['path'] => $entity['namespace']));
+                            $chain->addDriver($driver, $entity['namespace']);
+                            break;
                         case 'xml':
                             $driver = new XmlDriver($entity['path']);
+                            $chain->addDriver($driver, $entity['namespace']);
+                            break;
+                        case 'simple_xml':
+                            $driver = new SimplifiedXmlDriver(array($entity['path'] => $entity['namespace']));
                             $chain->addDriver($driver, $entity['namespace']);
                             break;
                         case 'php':

--- a/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
+++ b/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
@@ -321,7 +321,12 @@ class DoctrineOrmServiceProvider
             if (empty($cacheOptions['path'])) {
                 throw new \RuntimeException('FilesystemCache path not defined');
             }
-            return new FilesystemCache($cacheOptions['path']);
+
+            $cacheOptions += array(
+                'extension' => FilesystemCache::EXTENSION,
+                'umask' => 0002,
+            );
+            return new FilesystemCache($cacheOptions['path'], $cacheOptions['extension'], $cacheOptions['umask']);
         });
 
         $app['orm.cache.factory'] = $app->protect(function($driver, $cacheOptions) use ($app) {

--- a/tests/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProviderTest.php
+++ b/tests/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProviderTest.php
@@ -110,7 +110,7 @@ class DoctrineOrmServiceProviderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertContains('/../../../../../../../cache/doctrine/proxies', $app['orm.em.config']->getProxyDir());
         $this->assertEquals('DoctrineProxy', $app['orm.em.config']->getProxyNamespace());
-        $this->assertTrue($app['orm.em.config']->getAutoGenerateProxyClasses());
+        $this->assertEquals(1, $app['orm.em.config']->getAutoGenerateProxyClasses());
     }
 
     /**
@@ -140,7 +140,7 @@ class DoctrineOrmServiceProviderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('/path/to/proxies', $app['orm.em.config']->getProxyDir());
         $this->assertEquals('TestDoctrineOrmProxiesNamespace', $app['orm.em.config']->getProxyNamespace());
-        $this->assertFalse($app['orm.em.config']->getAutoGenerateProxyClasses());
+        $this->assertEquals(0, $app['orm.em.config']->getAutoGenerateProxyClasses());
         $this->assertEquals($metadataFactoryName, $app['orm.em.config']->getClassMetadataFactoryName());
         $this->assertEquals($entityRepositoryClassName, $app['orm.em.config']->getDefaultRepositoryClassName());
         $this->assertEquals($entityListenerResolver, $app['orm.em.config']->getEntityListenerResolver());


### PR DESCRIPTION
The namespace are reference to Cilex\Application and Cilex\ServiceProviderInterface instead of the correct namespaces Silex\Application and Silex\ServiceProviderInterface.