### PR TITLE
Fixed the namespace for Silex

### DIFF
--- a/src/Dflydev/Cilex/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
+++ b/src/Dflydev/Cilex/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
@@ -12,8 +12,8 @@
 namespace Dflydev\Cilex\Provider\DoctrineOrm;
 
 use Dflydev\Pimple\Provider\DoctrineOrm\DoctrineOrmServiceProvider as PimpleDoctrineOrmServiceProvider;
-use Cilex\Application;
-use Cilex\ServiceProviderInterface;
+use Silex\Application;
+use Silex\ServiceProviderInterface;
 
 /**
  * Doctrine ORM Cilex Service Provider.


### PR DESCRIPTION
The namespace are reference to Cilex\Application and Cilex\ServiceProviderInterface instead of the correct namespaces Silex\Application and Silex\ServiceProviderInterface.