### PR TITLE
Added database option to redis cache, per driver cache namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,9 @@ Configuration
      String or array describing result cache implementation.
    * **hydration_cache** (Default: setting specified by orm.default_cache):
      String or array describing hydration cache implementation.
-   * **types**
+   * **cache_namespace**:
+     String to define a global namespace for cached keys.
+   * **types**:
      An array of custom types in the format of 'typeName' => 'Namespace\To\Type\Class'
  * **orm.ems.options**:
    Array of Entity Manager configuration sets indexed by each Entity Manager's
@@ -290,6 +292,31 @@ Configuration
    `Doctrine\ORM\Mapping\EntityListenerResolver`.
  * **orm.default_cache**:
    String or array describing default cache implementation.
+   
+   Example configuration:
+   ```php
+   <?php
+   $app['orm.ems.options'] = array(
+      // php array cache defined globally
+      'orm.default_cache' => 'array',
+      // or
+      'orm.default_cache' => array('driver' => 'array'),
+
+      // or redis cache defined as metadata cache on the default em
+      'default' => array(
+         ...
+         'metadata_cache' => array(
+            'driver' => 'redis',
+            'host' => '127.0.0.1', // mandatory redis host
+            'port' => 6379, // mandatory redis port
+            'password' => 'mypassword', // optional redis password
+            'database' => 1, // optional redis database, default: 0
+            'namespace' => 'MYNAMESPACE:' // optional namespace for this cache, otherwise cache_namespace from the current em will be used
+         )
+         ...
+      )
+   );
+   ```
  * **orm.add_mapping_driver**:
    Function providing the ability to add a mapping driver to an Entity Manager.
 

--- a/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
+++ b/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
@@ -240,8 +240,12 @@ class DoctrineOrmServiceProvider
 
             $cache = $app['orm.cache.factory']($driver, $options[$cacheNameKey]);
 
-            if(isset($options['cache_namespace']) && $cache instanceof CacheProvider) {
-                $cache->setNamespace($options['cache_namespace']);
+            if ($cache instanceof CacheProvider) {
+                if (isset($options[$cacheNameKey]['namespace'])) {
+                    $cache->setNamespace($options[$cacheNameKey]['namespace']);
+                } elseif (isset($options['cache_namespace'])) {
+                    $cache->setNamespace($options['cache_namespace']);
+                }
             }
 
             return $app[$cacheInstanceKey] = $cache;

--- a/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
+++ b/src/Dflydev/Pimple/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
@@ -292,11 +292,16 @@ class DoctrineOrmServiceProvider
                 throw new \RuntimeException('Host and port options need to be specified for redis cache');
             }
 
+            /** @var \Redis $redis */
             $redis = $app['orm.cache.factory.backing_redis']();
             $redis->connect($cacheOptions['host'], $cacheOptions['port']);
 
             if (isset($cacheOptions['password'])) {
                 $redis->auth($cacheOptions['password']);
+            }
+
+            if (isset($cacheOptions['database'])) {
+                $redis->select($cacheOptions['database']);
             }
 
             $cache = new RedisCache;


### PR DESCRIPTION
While configuration a Silex project with orm and caches, I needed some more options:
* a database option when using the redis cache
* a namespace that can be set for each cache type

Also added examples in the readme on how to configure caches.