### PR TITLE
Added support for APCu Cache driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 composer.lock
 vendor
+.idea

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Configuration
  * **orm.default_cache**:
    String or array describing default cache implementation.
    * Available cache implementations, one of `array`, `filesystem`, `apc`, `apcu`, `memcache`, `memcached`, `redis`,
-     `xcache` or `couchbase`
+     `xcache` or `couchbase`. Some implementations may require more configuration than others.
  * **orm.add_mapping_driver**:
    Function providing the ability to add a mapping driver to an Entity Manager.
 

--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ Configuration
    `Doctrine\ORM\Mapping\EntityListenerResolver`.
  * **orm.default_cache**:
    String or array describing default cache implementation.
+   * Available cache implementations, one of `array`, `filesystem`, `apc`, `apcu`, `memcache`, `memcached`, `redis`,
+     `xcache` or `couchbase`
  * **orm.add_mapping_driver**:
    Function providing the ability to add a mapping driver to an Entity Manager.
 

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,9 @@
         "pimple/pimple": ">=2.1,<4",
         "doctrine/orm": "~2.3"
     },
+    "require-dev": {
+        "phpunit/phpunit" : "~4.0"
+    },
     "autoload": {
         "psr-4": {
             "Dflydev\\Provider\\DoctrineOrm\\": "src/Dflydev/Provider/DoctrineOrm"

--- a/src/Dflydev/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
+++ b/src/Dflydev/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
@@ -12,6 +12,7 @@
 namespace Dflydev\Provider\DoctrineOrm;
 
 use Doctrine\Common\Cache\ApcCache;
+use Doctrine\Common\Cache\ApcuCache;
 use Doctrine\Common\Cache\ArrayCache;
 use Doctrine\Common\Cache\CacheProvider;
 use Doctrine\Common\Cache\FilesystemCache;
@@ -319,6 +320,10 @@ class DoctrineOrmServiceProvider implements ServiceProviderInterface
 
         $container['orm.cache.factory.apc'] = $container->protect(function () {
             return new ApcCache;
+        });
+
+        $container['orm.cache.factory.apcu'] = $container->protect(function () {
+            return new ApcuCache;
         });
 
         $container['orm.cache.factory.xcache'] = $container->protect(function () {


### PR DESCRIPTION
With PHP 7.0 (and availability to use OPcache), APC is no longer the only opcode cache extension. APCu as been made available to replace the key/value component of APC.

APCu is officially supported in Doctrine\Cache since v. 1.6

I did not include any new tests since there was none to test other services, but I can, if they are required
