### PR TITLE
Fixed default proxies_dir value.

### DIFF
--- a/src/Dflydev/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
+++ b/src/Dflydev/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
@@ -438,7 +438,7 @@ class DoctrineOrmServiceProvider implements ServiceProviderInterface
     protected function getOrmDefaults()
     {
         return array(
-            'orm.proxies_dir' => __DIR__.'/../../../../../../../../cache/doctrine/proxies',
+            'orm.proxies_dir' => __DIR__.'/../../../../../../../cache/doctrine/proxies',
             'orm.proxies_namespace' => 'DoctrineProxy',
             'orm.auto_generate_proxies' => true,
             'orm.default_cache' => array(


### PR DESCRIPTION
The default value did not resolve to the root path, but its parent directory. Now the cache directory will be in the same directory as 'vendor', i.e. the root directory of the project.

*Note: As far as I understand this code right now, using this path may be unstable, as it highly depends on the current file location. If e.g. one would move the file, this path is not valid anymore. I would suggest to check for a constant or something similar to check, if the user provides a root path, e.g.`ROOT`.*