### PR TITLE
Fix travis php 5.3 and 5.3.3 runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ cache:
     - $HOME/.composer/cache
 
 before_script:
+  - if [ $(phpenv version-name) = "5.3.3" ]; then composer config disable-tls true; fi
   - composer install --prefer-dist
 
 script: phpunit --coverage-text --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: precise
+
 sudo: false
 
 php:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ cache:
     - $HOME/.composer/cache
 
 before_script:
-  - if [ $(phpenv version-name) = "5.3.3" ]; then composer config disable-tls true; fi
+  - if [ $(phpenv version-name) = "5.3.3" ]; then composer config disable-tls true && composer config secure-http false; fi
   - composer install --prefer-dist
 
 script: phpunit --coverage-text --verbose


### PR DESCRIPTION
Travis was failing builds for php 5.3 and 5.3.3 builds.

Downgrade to **dist precise** (ref travis-ci/travis-ci/issues/7693).

Disabled Composer HTTPS for php 5.3.3 (ref https://docs.travis-ci.com/user/languages/php)
 > The OpenSSL extension is switched off on php 5.3.3 because of compilation problems with OpenSSL 1.0.

Btw: I would like to see a new hotfix version after this soon.