### PR TITLE
Update proxies_dir in DoctrineOrmServiceProvider

### DIFF
--- a/src/Dflydev/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
+++ b/src/Dflydev/Provider/DoctrineOrm/DoctrineOrmServiceProvider.php
@@ -438,7 +438,7 @@ class DoctrineOrmServiceProvider implements ServiceProviderInterface
     protected function getOrmDefaults()
     {
         return array(
-            'orm.proxies_dir' => __DIR__.'/../../../../../../../../cache/doctrine/proxies',
+            'orm.proxies_dir' => __DIR__.'/../../../../../../../cache/doctrine/proxies',
             'orm.proxies_namespace' => 'DoctrineProxy',
             'orm.auto_generate_proxies' => true,
             'orm.default_cache' => array(


### PR DESCRIPTION
There is one "../" too many in proxies_dir value.
In v1 there was an additional subfolder (Cilex or Pimple or Silex) between Dflydev and Provider.
In this version there is no intermediate folder. Which means we need to go back one folder less. So only 7 "../" in v2 instead of 8 in v1
My project fails to write in cache folder because due to security settings in our openshift container, we only have access to www root folder. With this, we go one folder above, and it fails to write in the parent folder for which we don't have the permissions.